### PR TITLE
add trova e sostituisci parola entro parentesi quadre

### DIFF
--- a/ricette/regex.md
+++ b/ricette/regex.md
@@ -46,6 +46,11 @@ Vedi issue [#1](https://github.com/opendatasicilia/tansignari/issues/1)
 
 Vedi issue [#2](https://github.com/opendatasicilia/tansignari/issues/2)
 
+## Trovo e sostituisco un testo tra parentesi quadre
+
+* `(\[)(.*)(\])(.*)` - testo tra parentesi quadre (ad inizio stringa); [test](https://regex101.com/r/CJIy2e/2/)
+* `$2` per la sostituzione dell'intera stringa con la solo parola entra parentesi quadre
+
 # Siti utili
 
 - **regex101**, per testare espressioni regolari e imparare a usarle [https://regex101.com/](https://regex101.com/)


### PR DESCRIPTION
Ho aggiunto una piccola ricetta per la ricerca e sostituzione di parte di un testo

es:
`[$area](funzioni/$area.md)|Restituisce l'area della geometria corrente|2.18`

trovare solo il testo tra parentesi quadre e sostituirlo solo con il testo tra parentesi quadre